### PR TITLE
Links to posts respect baseurl setting

### DIFF
--- a/_layouts/articles_by_tag.html
+++ b/_layouts/articles_by_tag.html
@@ -6,7 +6,7 @@ layout: default
   <ul class="article-list">
     {% for post in site.tags[page.slug] %}
       <li class="article-list-item reveal">
-        <a href="{{ post.url }}" title="{{ post.title }}">
+        <a href="{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}">
           <h5>{{ post.title }}</h5>
         </a>
         <p>{{ post.description }}</p>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ description: "Chalk uses all the best tools and merges them into one premium blo
 <ul class="article-list">
   {% for post in paginator.posts %}
     <li class="article-list-item reveal">
-      <a href="{{ post.url }}" title="{{ post.title }}">
+      <a href="{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}">
         <h5>
           {{ post.title }}
           <span class="icon icon-ios-arrow-thin-right"></span>


### PR DESCRIPTION
When setting a baseurl in _config.xml post links breaks as they are
not prepended with the baseurl. Adding the baseurl to the template
fixes this issue.