### PR TITLE
Use social media handles instead of urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,10 +13,10 @@ discus_identifier: # Add your Disqus identifier
 ga_analytics: # Add your GA Tracking Id
 rss_enabled: true # Change to false if not
 social:
-  dribbble: # Add your Dribbble link
-  facebook: # Add your Facebook link
-  github: # Add your GitHub link
-  linkedin: # Add your LinkedIn link
+  dribbble: # Add your Dribbble handle
+  facebook: # Add your Facebook handle
+  github: # Add your GitHub handle
+  linkedin: # Add your LinkedIn handle
   twitter: # Add your Twitter handle
   email: # Add your Email address
   bitcoin: # Add your Bitcoin link or address

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,35 +3,35 @@
   <ul class="header-links">
     {% if site.social.twitter %}
       <li>
-        <a href="http://twitter.com/{{ site.social.twitter }}" target="_blank" title="Twitter">
+        <a href="https://twitter.com/{{ site.social.twitter }}" target="_blank" title="Twitter">
           <span class="icon icon-social-twitter"></span>
         </a>
       </li>
     {% endif %}
     {% if site.social.facebook %}
       <li>
-        <a href="{{ site.social.facebook }}" target="_blank" title="Facebook">
+        <a href="https://www.facebook.com/{{ site.social.facebook }}" target="_blank" title="Facebook">
           <span class="icon icon-social-facebook"></span>
         </a>
       </li>
     {% endif %}
     {% if site.social.github %}
       <li>
-        <a href="{{ site.social.github }}" target="_blank" title="GitHub">
+        <a href="https://github.com/{{ site.social.github }}" target="_blank" title="GitHub">
           <span class="icon icon-social-github"></span>
         </a>
       </li>
     {% endif %}
     {% if site.social.dribbble %}
       <li>
-        <a href="{{ site.social.dribbble }}" target="_blank" title="Dribbble">
+        <a href="https://dribbble.com/{{ site.social.dribbble }}" target="_blank" title="Dribbble">
           <span class="icon icon-social-dribbble-outline"></span>
         </a>
       </li>
     {% endif %}
     {% if site.social.linkedin %}
       <li>
-        <a href="{{ site.social.linkedin }}" target="_blank" title="LinkedIn">
+        <a href="https://www.linkedin.com/in/{{ site.social.linkedin }}" target="_blank" title="LinkedIn">
           <span class="icon icon-social-linkedin"></span>
         </a>
       </li>


### PR DESCRIPTION
I thought it might be easier to just use social media handles instead of full urls and seems more maintainable to have to update this repo in case any of them change instead of every forks config.
Feel free to close this if you disagree.