### PR TITLE
Remove target='blank' for email

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -59,7 +59,7 @@
     {% endif %}
     {% if site.social.email %}
       <li>
-        <a href="mailto:{{ site.social.email }}" target="_blank" title="Email">
+        <a href="mailto:{{ site.social.email }}" title="Email">
           <span class="icon icon-at"></span>
         </a>
       </li>


### PR DESCRIPTION
Suggesting to remove `target="_blank"` since the default browser behaviour is opening the users default email client. Now I get the default behaviour + a blank page I will have to close afterwards.