### PR TITLE
"Chalk" literal to site.name varriable

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,7 +20,7 @@ sitemap: false
 <body>
   <main role="main" class="notfound-wrapper">
     <div class="notfound-content">
-      <h1><a href="{{ '/' | relative_url }}" title="Back to homepage">Chalk</a></h1>
+      <h1><a href="{{ '/' | relative_url }}" title="Back to homepage">{{ site.name }}</a></h1>
       <p>
         Looks like you got lost. Let's get you back to the <a href="{{ '/' | relative_url }}">homepage</a>!
       </p>


### PR DESCRIPTION
Previously, the 404 page said "Chalk", now it instead displays the site name with the liquid tag {{ site.name }}.