### PR TITLE
add '/' after 'posts/:slug'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,4 +63,4 @@ gems:
   - jekyll-paginate
   - jekyll-sitemap
   - jemoji
-permalink: posts/:slug
+permalink: posts/:slug/


### PR DESCRIPTION
The last line of file "_config.yml" is "permalink: posts/:slug" .
Is missing a "/" ? It should be "permalink: posts/:slug/" ?