### PR TITLE
Fix ga snippet

### DIFF
--- a/_assets/javascripts/application.js
+++ b/_assets/javascripts/application.js
@@ -1,13 +1,12 @@
 //= require_self
 
-$(document).on('turbolinks:load', function (event) {
+$(document).on('turbolinks:load', function () {
   // Initialize fluidbox
   $('.fluidbox-trigger').fluidbox();
 
   // Track page views on Turbolinks
   if (typeof ga === 'function') {
-    ga('set', 'location', event.data.url)
-    ga('send', 'pageview')
+    ga('send', 'pageview', location.pathname);
   }
 
   // Initialize scrollreveal

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,6 +1,3 @@
-{% javascript vendor %}
-{% javascript application %}
-
 <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
 <script>
   WebFont.load({
@@ -17,3 +14,6 @@
   </script>
   <script src="https://www.google-analytics.com/analytics.js" async defer></script>
 {% endif %}
+
+{% javascript vendor %}
+{% javascript application %}


### PR DESCRIPTION
Chalk currently fails to submit a page view event to Google Analytics for initial visits. I believe this is due to either the order in which assets are being loaded, or where the theme is getting page URLs. This PR updates both aspects and should resolve the JS error. These changes still need to be tested in a production environment.