### PR TITLE
Using arbitrary branch in the build script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ Run Jekyll:
 
 ## Deploy to GitHub Pages
 
-Before you deploy, commit your changes to any working branch except the `gh-pages` one then run the following command:
+Before you can deploy to GitHub pages you need to specify the branch to use in the `bin/branch.cfg` file. This must be the 
+branch the your GitHub page uses it can be found in your repository settings.
+Before you deploy, commit your changes to any working branch except the branch specified in `bin/branch.cfg` then run the following command:
 
     bin/deploy
 
 **Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch with the `bin/deploy` script. This is because Chalk uses Jekyll plugins that aren't supported by GitHub pages.
 
-You can find more info on how to use the gh-pages branch and a custom domain [here](https://help.github.com/articles/quick-start-setting-up-a-custom-domain/).
+You can find more info on how to use GitHub pages and a custom domain [here](https://help.github.com/articles/quick-start-setting-up-a-custom-domain/).
 
 [View this](https://github.com/nielsenramon/kickster#automated-deployment-with-circle-ci) for more info about automated deployment with Circle CI.
 

--- a/bin/branch.cfg
+++ b/bin/branch.cfg
@@ -1,0 +1,2 @@
+#write the name of the branch to which you want to deploy on the line below.
+

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,12 +7,20 @@ set -e
 
 echo "Started deploying"
 
-# Checkout gh-pages branch.
-if [ `git branch | grep gh-pages` ]
+BRANCH=$(sed -n '2p' branch.cfg)
+
+case $BRANCH in
+  (*[![:blank:]]*) echo "Deploying to branch $BRANCH";;
+  (*) echo 'Branch not set in branch.cfg' ; exit 1
+esac
+
+if [ `git branch | grep $BRANCH` ]
 then
-  git branch -D gh-pages
+  git checkout $BRANCH
+else
+  echo "Branch $BRANCH does not exist. Please create it using: git checkout -b $BRANCH"
+  exit 1
 fi
-git checkout -b gh-pages
 
 # Build site.
 bower install
@@ -23,10 +31,10 @@ find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name '.gitignore' -exec rm 
 mv _site/* .
 rm -R _site/
 
-# Push to gh-pages.
+# Push to selected branch.
 git add -fA
 git commit --allow-empty -m "$(git log -1 --pretty=%B) [ci skip]"
-git push -f -q origin gh-pages
+git push -f -q origin $BRANCH
 
 # Move back to previous branch.
 git checkout -


### PR DESCRIPTION
Since GitHub pages supports using other branches than the `gh-pages`  branch for a GitHub page the old `bin/deploy` script didn't work since it was hard-coded to use the `gh-pages` branch.

I decided to let the branch to be used by the script be stored in the file `bin/branch.cfg` since the branch to use will most likely not change very often.

I also removed the deleting of the deploy branch. I didn't understand why this was necessary and it just felt a bit confusing. But if it was key I can fix it.

I'm not very good at writing bash scripts (or writing anything in general) so if you think there is a better solution to this then please let me know.