### PR TITLE
Remove misplaced .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 !.keep
-*.DS_Store
 *.sass-cache
 /.asset-cache/*
 /_site/*


### PR DESCRIPTION
OS-specific entries, like `*.DS_Store`, should reside in a global .gitignore, created by each user to fit their needs.

Example:
`git config --global core.excludesfile '~/.gitignore'`

`echo '*.DS_Store' >> ~/.gitignore`