### PR TITLE
Added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.7
+
+# Build
+RUN apk --update --no-cache add \
+    ruby \
+    ruby-dev \
+    ruby-rdoc \
+    ruby-irb \
+    ruby-nokogiri \
+    nodejs \
+    build-base \
+    g++ \
+    make \
+    musl-dev \
+    libffi-dev
+COPY Gemfile /build/
+COPY package.json /build/
+COPY bin/setup /build/bin/setup
+WORKDIR /build
+RUN bin/setup
+
+# Run
+EXPOSE 4000
+WORKDIR /blog
+VOLUME ["/blog"]
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ Used tools
 ## Usage
 
 ### Installation
+You can run Chalk via Docker or locally.
 
+#### Docker
+If you have docker installed, run:
+
+    bin/docker-setup
+
+This will create a docker image with the necessary dependencies to build and run Chalk.
+
+#### Locally
 If you haven't installed the following tools then go ahead and do so (make sure you have [Homebrew](https://brew.sh/) installed):
 
     brew install ruby
@@ -65,6 +74,11 @@ Next setup your environment:
 
 ### Development
 
+### Docker
+
+    bin/docker-serve
+
+#### Locally
 Run Jekyll:
 
     bundle exec jekyll serve
@@ -73,7 +87,11 @@ Run Jekyll:
 
 Before you deploy, commit your changes to any working branch except the `gh-pages` one and run the following command:
 
-    bin/deploy
+    Docker install:
+    $ bin/docker-deploy
+     
+    Local install:
+    $ bin/deploy
 
 **Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `bin/deploy` script. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `bin/deploy` script will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,6 +7,14 @@ set -e
 
 echo "Started deploying"
 
+DOCKER_CMD=''
+if [ $1 = '--docker' ]
+then
+  SCRIPT=$( realpath -s "$0" ) 
+  REPO_DIR=`dirname $(dirname ${SCRIPT})`
+  DOCKER_CMD='docker run -v '$REPO_DIR':/blog -t jekyll-chalk'
+fi
+
 # Checkout gh-pages branch.
 if [ `git branch | grep gh-pages` ]
 then
@@ -15,13 +23,13 @@ fi
 git checkout -b gh-pages
 
 # Build site.
-yarn install --modules-folder ./_assets/yarn
-bundle exec jekyll build
+$DOCKER_CMD yarn install --modules-folder ./_assets/yarn
+$DOCKER_CMD bundle exec jekyll build
 
 # Delete and move files.
-find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name '.gitignore' -exec rm -rf {} \;
-mv _site/* .
-rm -R _site/
+$DOCKER_CMD find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name '.gitignore' -exec rm -rf {} \;
+$DOCKER_CMD mv _site/* .
+$DOCKER_CMD rm -R _site/
 
 # Push to gh-pages.
 git add -fA
@@ -29,8 +37,9 @@ git commit --allow-empty -m "$(git log -1 --pretty=%B) [ci skip]"
 git push -f -q origin gh-pages
 
 # Move back to previous branch.
-git checkout -
-yarn install --modules-folder ./_assets/yarn
+$DOCKER_CMD find . -maxdepth 1 ! -name '.git' ! -name '.gitignore' -exec rm -rf {} \;
+git checkout -f -
+$DOCKER_CMD yarn install --modules-folder ./_assets/yarn
 
 echo "Deployed Successfully!"
 

--- a/bin/docker-deploy
+++ b/bin/docker-deploy
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+SCRIPT=$( realpath -s "$0" ) 
+REPO_DIR=`dirname $(dirname ${SCRIPT})`
+$REPO_DIR/bin/deploy --docker

--- a/bin/docker-serve
+++ b/bin/docker-serve
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+SCRIPT=$( realpath -s "$0" ) 
+REPO_DIR=`dirname $(dirname ${SCRIPT})`
+docker run \
+    -p 4000:4000 \
+    -v $REPO_DIR:/blog \
+    -i \
+    -t jekyll-chalk

--- a/bin/docker-setup
+++ b/bin/docker-setup
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+SCRIPT=$( realpath -s "$0" ) 
+REPO_DIR=`dirname $(dirname ${SCRIPT})`
+cd $REPO_DIR
+
+docker build . -t jekyll-chalk
+docker run \
+    -v $REPO_DIR:/blog \
+    -t jekyll-chalk \
+    yarn install --modules-folder /blog/_assets/yarn


### PR DESCRIPTION
## Changes
- Created a custom Dockerfile with all the necessary dependencies to build Chalk
- Created a series of scripts to build, serve and deploy chalk via the docker image
- Modified README.md with usage examples

## Rationale
The docker image uses volumes to mount the repo. This allows us to generate the *_site* in the repo itself but using the docker binaries instead of the local install. That works seamlessly in OSX, since the default volume behaviour is that the ownership of the files will be mapped depending on whether you are in the container or outside of it (files inside the container would be owned by root, whereas outside of it by your local user). This is **NOT** the case in Linux. Basically Linux maintains the user that created the files, so if you build your site using docker, as root, the *_site* folder will be owned by root, even outside the container. This is why all the file operations in the *deploy* script are executed inside the container.

## Testing
The PR has been tested on both OSX (High Sierra) and Ubuntu 16.04.
