### PR TITLE
Created NPM scripts in package.json to replace current build commands (and added Drafts support).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Thumbs.db
 /.jekyll-cache/
 Gemfile.lock
 yarn.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Before you deploy, commit your changes to any working branch except the `gh-page
 
     npm run publish
 
-**Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `bin/deploy` script. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `bin/deploy` script will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
+**Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `npm run publish` command. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `npm run publish` command will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
 
 You can find more info on how to use the `gh-pages` branch and a custom domain [here](https://help.github.com/articles/quick-start-setting-up-a-custom-domain/).
 

--- a/README.md
+++ b/README.md
@@ -61,19 +61,19 @@ On windows, install Ruby and Node with the installers found here:
 
 Next setup your environment:
 
-    bin/setup
+    npm run setup
 
 ### Development
 
 Run Jekyll:
 
-    bundle exec jekyll serve
+    npm run local
 
 ## Deploy to GitHub Pages
 
 Before you deploy, commit your changes to any working branch except the `gh-pages` one and run the following command:
 
-    bin/deploy
+    npm run publish
 
 **Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `bin/deploy` script. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `bin/deploy` script will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
 

--- a/_posts/2017-12-23-introducing-chalk.md
+++ b/_posts/2017-12-23-introducing-chalk.md
@@ -70,7 +70,7 @@ On windows, install Ruby and Node with the installers found here:
 Next setup your environment:
 
 {% highlight bash %}
-bin/setup
+npm run setup
 {% endhighlight %}
 
 ## Development
@@ -78,7 +78,7 @@ bin/setup
 Run Jekyll:
 
 {% highlight bash %}
-bundle exec jekyll serve
+npm run local
 {% endhighlight %}
 
 ## Deploy to GitHub Pages
@@ -86,10 +86,10 @@ bundle exec jekyll serve
 Before you deploy, commit your changes to any working branch except the `gh-pages` one and run the following command:
 
 {% highlight bash %}
-bin/deploy
+npm run publish
 {% endhighlight %}
 
-**Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `bin/deploy` script. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `bin/deploy` script will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
+**Important note**: Chalk does not support the standard way of Jekyll hosting on GitHub Pages. You need to deploy your working branch (can be any branch, for xxx.github.io users: use another branch than `master`) with the `npm run publish` command. Reason for this is because Chalk uses Jekyll plugins that aren't supported by GitHub pages. The `npm run publish` command will automatically build the entire project, then push it to the `gh-pages` branch of your repo. The script creates that branch for you so no need to create it yourself.
 
 You can find more info on how to use the `gh-pages` branch and a custom domain [here](https://help.github.com/articles/quick-start-setting-up-a-custom-domain/).
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "chalk",
+  "scripts": {
+    "setup": "bin/setup",
+    "local": "bundle exec jekyll serve --drafts",
+    "publish": "bin/deploy"
+  },
   "dependencies": {
     "jquery": "^3.2.1",
     "throttle-debounce-fn": "^1.0.1",


### PR DESCRIPTION
& Added Intellij system files to .gitignore

# Changes
- Created `npm run` commands for the build, development, and publish features of the theme.
  - `bin/setup` -> `npm run setup`
  - `bundle exec jekyll serve` -> `npm run local`
  - `bin/deploy` -> `npm run publish`
- Added the `--drafts` flag to `bundle exec jekyll serve` so [draft articles](https://jekyllrb.com/docs/drafts/) will work.

# Rationale
Changes to the commands (like adding `--drafts`) can occur without the user having to change the command they run. They run `npm run local` and behind the scenes the maintainers can update that command's function as needed.

Instead of having to remember longer commands or file paths, just run `npm run <the thing you want>` and it Shall Be Done for you. This was more of a pet peeve of mine.

# Testing
This is not platform-dependent and all commands have been tested to work successfully.

# Concerns
NPM has some standard commands (`publish` is [one of them](https://docs.npmjs.com/misc/scripts)). If you run `npm publish` on this repo, the command will fail and give an error message that will lead the user down a red herring. They won't know that the command they want is `npm run publish`. The fix would be to rename the commands to any keyword that is not in the [list of scripts](https://docs.npmjs.com/misc/scripts), but I really like the word publish for the action that is happening. It probably makes more sense to make it `npm run deploy`, though.