### PR TITLE
Add utf8 character encoding

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>{{ site.name }} | {{ page.title }}</title>
   <meta name="description" content="{{ page.description }}">


### PR DESCRIPTION
Fix #26 

Adding utf-8 character encoding enables to display all languages.