### PR TITLE
Fix jekyll-assets get image dimensions

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -2,7 +2,7 @@
   <img src="{% asset '{{ include.path }}' @path %}" alt="{{ include.alt }}"
        data-rjs="{% asset '{{ include.path-detail }}' @path %}"
        data-action="zoom"
-       data-zooming-width="{{ assets[include.path-detail].width }}"
-       data-zooming-height="{{ assets[include.path-detail].height }}"
+       data-zooming-width="{{ assets[include.path-detail].dimensions.width }}"
+       data-zooming-height="{{ assets[include.path-detail].dimensions.height }}"
   />
 </a>


### PR DESCRIPTION
Latest jekyll-assets update changed .width/height to .dimensions.width/.dimensions.height