### PR TITLE
Fix typo

### DIFF
--- a/_assets/stylesheets/layouts/_grid.scss
+++ b/_assets/stylesheets/layouts/_grid.scss
@@ -53,7 +53,7 @@
 // Descendants
 // =============================================================================
 
-// Creates a grid cell. Add `with-[x]co`l to define the number of coloms the
+// Creates a grid cell. Add `with-[x]col` to define the number of coloms the
 // cell needs to span. Do not use 'with-[x]col` if you wish to span the entire
 // width.
 


### PR DESCRIPTION
Fix typo `` `with-[x]co`l `` to `` with-[x]col` `` in Descendants comment.