### PR TITLE
automatically generate _my_tags/<tag>.md

### DIFF
--- a/bin/tag_scraper
+++ b/bin/tag_scraper
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+TAGS="$(grep -h tags:  _posts/* | sed -E 's/tags: \[(.*)\]/\1,/' | xargs | sed -E 's/ |,$//g' | sed -E 's/,/\n/g' | sort | uniq)"
+if [ ! -d "_my_tags" ]
+then
+    mkdir "_my_tags"
+fi
+
+for i in ${TAGS}; do
+    echo found tag: $i
+    if [ -e "_my_tags/${i}.md" ]
+    then
+        echo found  _my_tags/${i}.md, not updating
+    else
+        echo creating  _my_tags/${i}.md
+        firstletter=$(echo $i | cut -c1 | tr ‘[[:lower:]]’ ‘[[:upper:]]’)
+        otherletters=$(echo $i | cut -c2-)
+        capitalized="${firstletter}${otherletters}"
+        cat << EOF > "_my_tags/$i.md"
+---
+slug: $i
+name: $capitalized
+---
+EOF
+    fi
+done

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "chalk",
   "scripts": {
     "setup": "bin/setup",
-    "local": "bundle exec jekyll serve --drafts",
-    "publish": "bin/deploy"
+    "local": "bin/tag_scraper && bundle exec jekyll serve --drafts",
+    "publish": "bin/tag_scraper && bin/deploy"
   },
   "dependencies": {
     "jquery": "^3.2.1",


### PR DESCRIPTION
added a new bash script to inspect posts and generate appropriate
entries in _my_tags/<tag>.md

should respect the settings for "_my_tags" in config.yml, but it
doesn't at this time...just hard coded to _my_tags

tag_scraper will not modify existing files...what if the user decides
to change the "slug"...I don't want to clobber that.

tag_scraper will not delete files that are no longer
needed...deletion needs to be a manual thing.

integrated tag_scraper into the package.json so that it runs on `npm
run local` and `npm run publish`