### PR TITLE
feat: Add theme toggle

### DIFF
--- a/_assets/icons/theme.svg
+++ b/_assets/icons/theme.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-theme" viewBox="0 0 16 16">
+<title>theme</title>
+<path d="M8 0c-4.418 0-8 3.582-8 8s3.582 8 8 8 8-3.582 8-8-3.582-8-8-8zM2 8c0-3.314 2.686-6 6-6v12c-3.314 0-6-2.686-6-6z"></path>
+</symbol>
+</svg>

--- a/_assets/javascripts/application.js
+++ b/_assets/javascripts/application.js
@@ -17,30 +17,3 @@ $(document).ready(function() {
     return false;
   });
 });
-
-//Theme initialize
-if (!localStorage.getItem('theme'))
-  localStorage.setItem('theme', "light");
-themer();
-
-// Theme toggle
-function toggle() {
-  if(localStorage.getItem('theme') == "light")
-    localStorage.setItem('theme', "dark");
-  else if(localStorage.getItem('theme') == "dark")
-    localStorage.setItem('theme', "light");
-  themer();
-}
-
-// Theme set
-function themer() {
-  var tone = localStorage.getItem('theme');
-  var light = document.getElementById("light");
-
-  if(tone == "dark"){
-    dark.disabled = false;
-  }
-  else{
-    dark.disabled = true;
-  }
-}

--- a/_assets/javascripts/application.js
+++ b/_assets/javascripts/application.js
@@ -17,3 +17,30 @@ $(document).ready(function() {
     return false;
   });
 });
+
+//Theme initialize
+if (!localStorage.getItem('theme'))
+  localStorage.setItem('theme', "light");
+themer();
+
+// Theme toggle
+function toggle() {
+  if(localStorage.getItem('theme') == "light")
+    localStorage.setItem('theme', "dark");
+  else if(localStorage.getItem('theme') == "dark")
+    localStorage.setItem('theme', "light");
+  themer();
+}
+
+// Theme set
+function themer() {
+  var tone = localStorage.getItem('theme');
+  var light = document.getElementById("light");
+
+  if(tone == "dark"){
+    dark.disabled = false;
+  }
+  else{
+    dark.disabled = true;
+  }
+}

--- a/_assets/javascripts/themetoggle.js
+++ b/_assets/javascripts/themetoggle.js
@@ -1,0 +1,26 @@
+//Theme initialize
+if (!localStorage.getItem('theme'))
+  localStorage.setItem('theme', "light");
+themer();
+
+// Theme toggle
+function toggle() {
+  if(localStorage.getItem('theme') == "light")
+    localStorage.setItem('theme', "dark");
+  else if(localStorage.getItem('theme') == "dark")
+    localStorage.setItem('theme', "light");
+  themer();
+}
+
+// Theme set
+function themer() {
+  var tone = localStorage.getItem('theme');
+  var light = document.getElementById("light");
+
+  if(tone == "dark"){
+    dark.disabled = false;
+  }
+  else{
+    dark.disabled = true;
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ url: # add your site url (format: https://example.com)
 
 # Optional settings
 
+theme_toggle: false # Change to true if you wish to show an icon in the navigation for dynamic theme toggling
 about_enabled: false # Change to true if you wish to show an icon in the navigation that redirects to the about page
 baseurl: # Set if blog doesn't sit at the root of the domain (format: /blog)
 discus_identifier: # Add your Disqus identifier

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,15 +35,32 @@
     {% asset fonts.css %}
   {% endif %}
 
-  {% if site.blog_theme == "light" %}
-    <link rel="icon" type="image/x-icon" href="{% asset favicon-light.ico @path %}">
-    <link rel="apple-touch-icon" href="{% asset apple-touch-icon-light.png @path %}">
-    <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
-    <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="true">
+  {% if site.theme_toggle == true %}
+
+    {% if site.blog_theme == "light" %}
+      <link rel="icon" type="image/x-icon" href="{% asset favicon-light.ico @path %}">
+      <link rel="apple-touch-icon" href="{% asset apple-touch-icon-light.png @path %}">
+      <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
+      <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="true">
+    {% else %}
+      <link rel="icon" type="image/x-icon" href="{% asset favicon-dark.ico @path %}">
+      <link rel="apple-touch-icon" href="{% asset apple-touch-icon-dark.png @path %}">
+      <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
+      <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="false">
+    {% endif %}
+
   {% else %}
-    <link rel="icon" type="image/x-icon" href="{% asset favicon-dark.ico @path %}">
-    <link rel="apple-touch-icon" href="{% asset apple-touch-icon-dark.png @path %}">
-    <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
-    <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="false">
+
+    {% if site.blog_theme == "light" %}
+      <link rel="icon" type="image/x-icon" href="{% asset favicon-light.ico @path %}">
+      <link rel="apple-touch-icon" href="{% asset apple-touch-icon-light.png @path %}">
+      {% asset light.css %}
+    {% else %}
+      <link rel="icon" type="image/x-icon" href="{% asset favicon-dark.ico @path %}">
+      <link rel="apple-touch-icon" href="{% asset apple-touch-icon-dark.png @path %}">
+      {% asset dark.css %}
+    {% endif %}
+
   {% endif %}
+  
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,10 +38,12 @@
   {% if site.blog_theme == "light" %}
     <link rel="icon" type="image/x-icon" href="{% asset favicon-light.ico @path %}">
     <link rel="apple-touch-icon" href="{% asset apple-touch-icon-light.png @path %}">
-    {% asset light.css %}
+    <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
+    <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="true">
   {% else %}
     <link rel="icon" type="image/x-icon" href="{% asset favicon-dark.ico @path %}">
     <link rel="apple-touch-icon" href="{% asset apple-touch-icon-dark.png @path %}">
-    {% asset dark.css %}
+    <link rel="stylesheet" type="text/css" title="light" id="light" href="{% asset light.css @path%}">
+    <link rel="stylesheet" type="text/css" title="dark" id="dark" href="{% asset dark.css @path%}" disabled="false">
   {% endif %}
 </head>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -19,3 +19,7 @@
 {% endif %}
 
 {% asset application.js %}
+
+{% if site.theme_toggle == true %}
+  {% asset themetoggle.js %}
+{% endif %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -169,10 +169,12 @@
         </a>
       </li>
     {% endif %}
-    <li>
-      <a onclick="toggle()" title="Toggle Theme">
-        {% include svg-icon.html icon="theme" %}
-      </a>
-    </li>
+    {% if site.theme_toggle == true %}
+      <li>
+        <a onclick="toggle()" title="Toggle Theme">
+          {% include svg-icon.html icon="theme" %}
+        </a>
+      </li>
+    {% endif %}
   </ul>
 </nav>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -169,5 +169,10 @@
         </a>
       </li>
     {% endif %}
+    <li>
+      <a onclick="toggle()" title="Toggle Theme">
+        {% include svg-icon.html icon="theme" %}
+      </a>
+    </li>
   </ul>
 </nav>


### PR DESCRIPTION
Add a navigation icon to toggle theme.

- loads both dark.css and light.css, toggles visibility via JavaScript
- use local storage to save theme state across pages