### PR TITLE
Add additional tag-list navigation bar

### DIFF
--- a/_assets/stylesheets/modules/_header.scss
+++ b/_assets/stylesheets/modules/_header.scss
@@ -44,6 +44,30 @@
   }
 }
 
+.tag-nav {
+  display: block;
+  padding-top: 20px;
+
+  .tag-links {
+    padding: 0
+  }
+  li {
+    display: inline-block;
+    margin-right: 7px;
+    vertical-align: middle;
+    &:first-child {
+      margin-left: 0;
+    }
+    a {
+      font-size: 15px;
+      color: $header-link-color;
+      text-decoration: none;
+      padding-right: 5px;
+    }
+  }
+
+}
+
 @include breakpoint(extra-small) {
   .header-nav {
     text-align: center;
@@ -54,6 +78,24 @@
     text-align: center;
     li {
       margin: 0 10px;
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+}
+
+@include breakpoint(extra-small) {
+  .tag-nav {
+    text-align: center;
+  }
+  .tag-links {
+    padding: 0;
+    display: block;
+    float: none;
+    text-align: center;
+    li {
+      margin: 0px;
       &:last-child {
         margin-right: 0;
       }

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ url: # add your site url (format: https://example.com)
 
 theme_toggle: false # Change to true if you wish to show an icon in the navigation for dynamic theme toggling
 about_enabled: false # Change to true if you wish to show an icon in the navigation that redirects to the about page
+navtags_enabled: false # Change to true if you wish to show an additional 'tag-list' nav below your original 'header' nav
 baseurl: # Set if blog doesn't sit at the root of the domain (format: /blog)
 discus_identifier: # Add your Disqus identifier
 ga_analytics: # Add your GA Tracking Id

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -178,3 +178,19 @@
     {% endif %}
   </ul>
 </nav>
+{% if site.navtags_enabled %}
+  <nav class="tag-nav">
+      <ul class="tag-links">
+          {% assign tags = site.tags | sort %}
+            {% for tag in tags %}
+              {% if forloop.index > 10 %}
+                <li>...</li>
+                <li><a href="/tags">Show all</a></li>
+                {% break %}
+              {% endif %}
+                <li><a href="{{ 'tag/' | relative_url }}{{ tag[0] }}">{{ tag[0] | capitalize }}</a></li>
+            {% endfor %}
+      </ul>
+  </nav>
+{% endif %}
+


### PR DESCRIPTION
Adds additional tag-list navigation bar  below the header navigation bar. 

This feature makes it easier for you to find  specific tagged posts. 


- If there are more than 10 tags throughout the site, shows the first 10 sorted tags with "... show all" anchor tag which redirects to the 'tag cloud' page.
- Else, just shows a list of all tags. The style follows the conventions of the existing repository.
- Turn on and off using a toggle option in config.yml

I've done my best to implement the style used in this pull request, but I'm not a professional web designer so slight modification might be needed.

### Web 

![image](https://user-images.githubusercontent.com/30017143/58443361-6126fd00-812c-11e9-9f71-c944aa73d9c1.png)

![image](https://user-images.githubusercontent.com/30017143/58443437-d85c9100-812c-11e9-9837-2afe04265225.png)

* Plz note that even though the number of tags in the picture above does not exceed 10, the word 'show all' appears. That's because my local blog has only 6 tags and the screenshot was taken during development. 

* I’m aware that the ‘convention’ for showing tags is UPPERCASE but I think Capitalize is prettier. 

### Mobile 

![image](https://user-images.githubusercontent.com/30017143/58443578-b0216200-812d-11e9-9f4a-d05611bc6d31.png)

