### PR TITLE
Add MathJax to support LaTeX

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ rss_enabled: true # Change to false if not
 scrollappear_enabled: true # Change to false to disable
 tag_nav_enabled: false # Change to true if you wish to show an additional 'tag-list' navigation below the header
 theme_toggle: false # Change to true if you wish to show an icon in the navigation for dynamic theme toggling
+mathjax_enabled: false # Change to true if you need LaTeX
 social:
   dribbble: nielsenramon # Add your Dribbble handle
   facebook: # Add your Facebook handle

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -73,7 +73,7 @@
   </script>
   {% endif %}
 
-  {% if mathjax_enabled %}
+  {% if site.mathjax_enabled %}
     <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,7 +63,7 @@
 
   {% endif %}
 
-  if site.ga_analytics %}
+  {% if site.ga_analytics %}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_analytics }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -73,14 +73,16 @@
   </script>
   {% endif %}
 
-  <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-      tex2jax: {
-        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-        inlineMath: [['$','$']]
-      }
-    });
-  </script>
+  {% if mathjax_enabled %}
+    <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {
+          skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+          inlineMath: [['$','$']]
+        }
+      });
+    </script>
+  {% endif %}
 
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,4 +63,14 @@
 
   {% endif %}
 
+  if site.ga_analytics %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_analytics }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{ site.ga_analytics }}');
+  </script>
+  {% endif %}
+
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -73,4 +73,14 @@
   </script>
   {% endif %}
 
+  <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      tex2jax: {
+        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+        inlineMath: [['$','$']]
+      }
+    });
+  </script>
+
 </head>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,13 +1,3 @@
-{% if site.ga_analytics %}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_analytics }}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', '{{ site.ga_analytics }}');
-  </script>
-{% endif %}
-
 {% asset vendor.js %}
 
 {% unless site.local_fonts %}


### PR DESCRIPTION
Hi,
I love your Chalk so much. It's very elegant.
I found I need LaTeX so I added MathJax to support it.

And there is an error in gtag.js, it should be in the head.html instead of the javascripts.html. Otherwise, Google Analytics will make an error when detecting gtag.js. So I move the gtag.js to the head.html.

And thanks for your works.